### PR TITLE
Adding Test and Prepare to PR upstream project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ build: clean fmt
 sanitize:
 	hooks/check_boilerplate.sh
 	hooks/check_gofmt.sh
-#	hooks/run_vet.sh
+	hooks/run_vet.sh
 
 test-unit: clean sanitize build
 ifeq ($(ARCH),amd64)

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ build: clean fmt
 sanitize:
 	hooks/check_boilerplate.sh
 	hooks/check_gofmt.sh
-	hooks/run_vet.sh
+#	hooks/run_vet.sh
 
 test-unit: clean sanitize build
 ifeq ($(ARCH),amd64)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 all: build
 
-PREFIX?=honeycombio
+PREFIX?=gcr.io/google_containers
 FLAGS=
 ARCH?=amd64
 ALL_ARCHITECTURES=amd64 arm arm64 ppc64le s390x
@@ -49,7 +49,7 @@ build: clean fmt
 sanitize:
 	hooks/check_boilerplate.sh
 	hooks/check_gofmt.sh
-	hooks/run_vet.sh
+#	hooks/run_vet.sh
 
 test-unit: clean sanitize build
 ifeq ($(ARCH),amd64)

--- a/common/honeycomb/dummy_honeycomb.go
+++ b/common/honeycomb/dummy_honeycomb.go
@@ -19,21 +19,19 @@ type BatchPointsSavedToHoneycomb struct {
 }
 
 type FakeHoneycombClient struct {
-	BatchPoints []BatchPointsSavedToHoneycomb
+	BatchPoints []*BatchPoint
 }
 
 func NewFakeHoneycombClient() *FakeHoneycombClient {
-	return &FakeHoneycombClient{[]BatchPointsSavedToHoneycomb{}}
+	return &FakeHoneycombClient{[]*BatchPoint{}}
 }
 
 func (client *FakeHoneycombClient) SendBatch(batch Batch) error {
 	for _, batchpoint := range batch {
-		client.BatchPoints = append(client.BatchPoints, BatchPointsSavedToHoneycomb{batchpoint})
+		client.BatchPoints = append(client.BatchPoints, batchpoint)
 	}
 	return nil
 }
-
-var FakeClient = NewFakeHoneycombClient()
 
 var Config = config{
 	Dataset:  "fake",

--- a/common/honeycomb/dummy_honeycomb.go
+++ b/common/honeycomb/dummy_honeycomb.go
@@ -1,0 +1,42 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package honeycomb
+
+type BatchPointsSavedToHoneycomb struct {
+	BatchPoint BatchPoint
+}
+
+type FakeHoneycombClient struct {
+	BatchPoints []BatchPointsSavedToHoneycomb
+}
+
+func NewFakeHoneycombClient() *FakeHoneycombClient {
+	return &FakeHoneycombClient{[]BatchPointsSavedToHoneycomb{}}
+}
+
+func (client *FakeHoneycombClient) Write(batchpoints []BatchPoint) error {
+	for _, batchpoint := range batchpoints {
+		client.BatchPoints = append(client.BatchPoints, BatchPointsSavedToHoneycomb{batchpoint})
+	}
+	return nil
+}
+
+var FakeClient = NewFakeHoneycombClient()
+
+var Config = config{
+	Dataset:  "fake",
+	WriteKey: "fakekey",
+	APIHost:  "fakehost",
+}

--- a/common/honeycomb/dummy_honeycomb.go
+++ b/common/honeycomb/dummy_honeycomb.go
@@ -15,7 +15,7 @@
 package honeycomb
 
 type BatchPointsSavedToHoneycomb struct {
-	BatchPoint BatchPoint
+	BatchPoint *BatchPoint
 }
 
 type FakeHoneycombClient struct {
@@ -26,8 +26,8 @@ func NewFakeHoneycombClient() *FakeHoneycombClient {
 	return &FakeHoneycombClient{[]BatchPointsSavedToHoneycomb{}}
 }
 
-func (client *FakeHoneycombClient) Write(batchpoints []BatchPoint) error {
-	for _, batchpoint := range batchpoints {
+func (client *FakeHoneycombClient) SendBatch(batch Batch) error {
+	for _, batchpoint := range batch {
 		client.BatchPoints = append(client.BatchPoints, BatchPointsSavedToHoneycomb{batchpoint})
 	}
 	return nil

--- a/common/honeycomb/honeycomb.go
+++ b/common/honeycomb/honeycomb.go
@@ -63,17 +63,21 @@ func BuildConfig(uri *url.URL) (*config, error) {
 	return config, nil
 }
 
-type Client struct {
+type Client interface {
+	SendBatch(batch Batch) error
+}
+
+type HoneycombClient struct {
 	config     config
 	httpClient http.Client
 }
 
-func NewClient(uri *url.URL) (*Client, error) {
+func NewClient(uri *url.URL) (*HoneycombClient, error) {
 	config, err := BuildConfig(uri)
 	if err != nil {
 		return nil, err
 	}
-	return &Client{config: *config}, nil
+	return &HoneycombClient{config: *config}, nil
 }
 
 type BatchPoint struct {
@@ -83,7 +87,7 @@ type BatchPoint struct {
 
 type Batch []*BatchPoint
 
-func (c *Client) SendBatch(batch Batch) error {
+func (c *HoneycombClient) SendBatch(batch Batch) error {
 	if len(batch) == 0 {
 		// Nothing to send
 		return nil
@@ -100,7 +104,7 @@ func (c *Client) SendBatch(batch Batch) error {
 	return nil
 }
 
-func (c *Client) makeRequest(body io.Reader) error {
+func (c *HoneycombClient) makeRequest(body io.Reader) error {
 	url, err := url.Parse(c.config.APIHost)
 	if err != nil {
 		return err

--- a/common/honeycomb/honeycomb.go
+++ b/common/honeycomb/honeycomb.go
@@ -35,7 +35,7 @@ type config struct {
 	WriteKey string
 }
 
-func buildConfig(uri *url.URL) (*config, error) {
+func BuildConfig(uri *url.URL) (*config, error) {
 	opts := uri.Query()
 
 	config := &config{
@@ -69,7 +69,7 @@ type Client struct {
 }
 
 func NewClient(uri *url.URL) (*Client, error) {
-	config, err := buildConfig(uri)
+	config, err := BuildConfig(uri)
 	if err != nil {
 		return nil, err
 	}

--- a/common/honeycomb/honeycomb_test.go
+++ b/common/honeycomb/honeycomb_test.go
@@ -1,0 +1,60 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package honeycomb
+
+import (
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	util "k8s.io/client-go/util/testing"
+)
+
+func TestHoneycombClientWrite(t *testing.T) {
+	handler := util.FakeHandler{
+		StatusCode:   202,
+		ResponseBody: "",
+		T:            t,
+	}
+	server := httptest.NewServer(&handler)
+	defer server.Close()
+
+	stubURL, err := url.Parse("?writekey=testkey&dataset=testdataset&apihost=" + server.URL)
+
+	assert.NoError(t, err)
+
+	config, err := BuildConfig(stubURL)
+
+	assert.Equal(t, config.WriteKey, "testkey")
+	assert.Equal(t, config.APIHost, server.URL)
+	assert.Equal(t, config.Dataset, "testdataset")
+
+	assert.NoError(t, err)
+
+	client := NewClient(*config)
+
+	err = client.SendBatch([]BatchPoint{
+		{
+			Data:      {"hello": "world"},
+			Timestamp: time.Now(),
+		},
+	})
+
+	assert.NoError(t, err)
+
+	handler.ValidateRequestCount(t, 1)
+}

--- a/common/honeycomb/honeycomb_test.go
+++ b/common/honeycomb/honeycomb_test.go
@@ -45,11 +45,11 @@ func TestHoneycombClientWrite(t *testing.T) {
 
 	assert.NoError(t, err)
 
-	client := NewClient(*config)
+	client, _ := NewClient(stubURL)
 
-	err = client.SendBatch([]BatchPoint{
+	err = client.SendBatch([]*BatchPoint{
 		{
-			Data:      {"hello": "world"},
+			Data:      "test",
 			Timestamp: time.Now(),
 		},
 	})

--- a/docs/sink-configuration.md
+++ b/docs/sink-configuration.md
@@ -284,6 +284,24 @@ For example,
 
 The librato sink currently only works with accounts, which support [tagged metrics](https://www.librato.com/docs/kb/faq/account_questions/tags_or_sources/).
 
+### Honeycomb
+
+This sink supports both monitoring metrics and events.
+
+To use the Honeycomb sink add the following flag:
+
+    --sink="honeycomb:<?<OPTIONS>>"
+
+Options can be set in query string, like this:
+
+* `dataset` - Honeycomb Dataset to which to publish metrics/events
+* `writekey` - Honeycomb Write Key for your account
+* `apihost` - Option to send metrics to a different host (default: https://api.honeycomb.com) (optional)
+
+For example,
+
+    --sink="honeycomb:?dataset=mydataset&writekey=secretwritekey"
+
 ## Using multiple sinks
 
 Heapster can be configured to send k8s metrics and events to multiple sinks by specifying the`--sink=...` flag multiple times.

--- a/events/sinks/factory.go
+++ b/events/sinks/factory.go
@@ -34,7 +34,6 @@ type SinkFactory struct {
 }
 
 func (this *SinkFactory) Build(uri flags.Uri) (core.EventSink, error) {
-	fmt.Println("BUILDING EVENT SINK")
 	switch uri.Key {
 	case "gcl":
 		return gcl.CreateGCLSink(&uri.Val)

--- a/events/sinks/honeycomb/driver.go
+++ b/events/sinks/honeycomb/driver.go
@@ -67,11 +67,11 @@ func (sink *honeycombSink) ExportEvents(eventBatch *event_core.EventBatch) {
 			Data:      data,
 			Timestamp: event.LastTimestamp.UTC(),
 		}
-		err := sink.client.SendBatch(exportedBatch)
-		if err != nil {
-			glog.Warningf("Failed to send event: %v", err)
-			return
-		}
+	}
+	err := sink.client.SendBatch(exportedBatch)
+	if err != nil {
+		glog.Warningf("Failed to send event: %v", err)
+		return
 	}
 }
 

--- a/events/sinks/honeycomb/driver.go
+++ b/events/sinks/honeycomb/driver.go
@@ -25,7 +25,7 @@ import (
 )
 
 type honeycombSink struct {
-	client *honeycomb_common.Client
+	client honeycomb_common.Client
 	sync.Mutex
 }
 

--- a/events/sinks/honeycomb/driver.go
+++ b/events/sinks/honeycomb/driver.go
@@ -1,3 +1,17 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package honeycomb
 
 import (

--- a/events/sinks/honeycomb/honeycomb_test.go
+++ b/events/sinks/honeycomb/honeycomb_test.go
@@ -33,11 +33,12 @@ type fakeHoneycombEventSink struct {
 }
 
 func NewFakeSink() fakeHoneycombEventSink {
+	fakeClient := honeycomb_common.NewFakeHoneycombClient()
 	return fakeHoneycombEventSink{
 		&honeycombSink{
-			client: honeycomb_common.FakeClient,
+			client: fakeClient,
 		},
-		honeycomb_common.FakeClient,
+		fakeClient,
 	}
 }
 

--- a/events/sinks/honeycomb/honeycomb_test.go
+++ b/events/sinks/honeycomb/honeycomb_test.go
@@ -1,0 +1,92 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package honeycomb
+
+import (
+	"testing"
+	"time"
+
+	"net/url"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kube_api "k8s.io/client-go/pkg/api/v1"
+	honeycomb_common "k8s.io/heapster/common/honeycomb"
+	"k8s.io/heapster/events/core"
+)
+
+type fakeHoneycombEventSink struct {
+	core.EventSink
+	fakeDbClient *honeycomb_common.FakeHoneycombClient
+}
+
+func NewFakeSink() fakeHoneycombEventSink {
+	return fakeHoneycombEventSink{
+		&honeycombSink{
+			client: honeycomb_common.FakeClient,
+		},
+		honeycomb_common.FakeClient,
+	}
+}
+
+func TestStoreDataEmptyInput(t *testing.T) {
+	fakeSink := NewFakeSink()
+	eventBatch := core.EventBatch{}
+	fakeSink.ExportEvents(&eventBatch)
+	assert.Equal(t, 0, len(fakeSink.fakeDbClient.BatchPoints))
+}
+
+func TestStoreMultipleDataInput(t *testing.T) {
+	fakeSink := NewFakeSink()
+	timestamp := time.Now()
+
+	now := time.Now()
+	event1 := kube_api.Event{
+		Message:        "event1",
+		Count:          100,
+		LastTimestamp:  metav1.NewTime(now),
+		FirstTimestamp: metav1.NewTime(now),
+	}
+
+	event2 := kube_api.Event{
+		Message:        "event2",
+		Count:          101,
+		LastTimestamp:  metav1.NewTime(now),
+		FirstTimestamp: metav1.NewTime(now),
+	}
+
+	data := core.EventBatch{
+		Timestamp: timestamp,
+		Events: []*kube_api.Event{
+			&event1,
+			&event2,
+		},
+	}
+
+	fakeSink.ExportEvents(&data)
+	assert.Equal(t, 2, len(fakeSink.fakeDbClient.BatchPoints))
+}
+
+func TestCreateHoneycombSink(t *testing.T) {
+	stubHoneycombURL, err := url.Parse("?dataset=testdataset&writekey=testwritekey")
+	assert.NoError(t, err)
+
+	//create honeycomb sink
+	sink, err := NewHoneycombSink(stubHoneycombURL)
+	assert.NoError(t, err)
+
+	//check sink name
+	assert.Equal(t, sink.Name(), "Honeycomb Sink")
+}

--- a/metrics/sinks/honeycomb/driver.go
+++ b/metrics/sinks/honeycomb/driver.go
@@ -37,7 +37,7 @@ var blacklist = map[string]struct{}{
 }
 
 type honeycombSink struct {
-	client *honeycomb_common.Client
+	client honeycomb_common.Client
 	sync.Mutex
 }
 

--- a/metrics/sinks/honeycomb/driver.go
+++ b/metrics/sinks/honeycomb/driver.go
@@ -1,3 +1,17 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package honeycomb
 
 import (

--- a/metrics/sinks/honeycomb/honeycomb_test.go
+++ b/metrics/sinks/honeycomb/honeycomb_test.go
@@ -1,0 +1,158 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package honeycomb
+
+import (
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	honeycomb_common "k8s.io/heapster/common/honeycomb"
+	"k8s.io/heapster/metrics/core"
+)
+
+type fakeHoneycombDataSink struct {
+	core.DataSink
+	fakeDbClient *honeycomb_common.FakeHoneycombClient
+}
+
+func newRawHoneycombSink() *honeycombSink {
+	return &honeycombSink{
+		client: honeycomb_common.FakeClient,
+		c:      honeycomb_common.Config,
+	}
+}
+
+func NewFakeSink() fakeHoneycombDataSink {
+	return fakeHoneycombDataSink{
+		newRawHoneycombSink(),
+		honeycomb_common.FakeClient,
+	}
+}
+func TestStoreDataEmptyInput(t *testing.T) {
+	fakeSink := NewFakeSink()
+	dataBatch := core.DataBatch{}
+	fakeSink.ExportData(&dataBatch)
+	assert.Equal(t, 0, len(fakeSink.fakeDbClient.Measurements))
+}
+
+func TestStoreMultipleDataInput(t *testing.T) {
+	fakeSink := NewFakeSink()
+	timestamp := time.Now()
+
+	l := make(map[string]string)
+	l["namespace_id"] = "123"
+	l["container_name"] = "/system.slice/-.mount"
+	l[core.LabelPodId.Key] = "aaaa-bbbb-cccc-dddd"
+
+	l2 := make(map[string]string)
+	l2["namespace_id"] = "123"
+	l2["container_name"] = "/system.slice/dbus.service"
+	l2[core.LabelPodId.Key] = "aaaa-bbbb-cccc-dddd"
+
+	l3 := make(map[string]string)
+	l3["namespace_id"] = "123"
+	l3[core.LabelPodId.Key] = "aaaa-bbbb-cccc-dddd"
+
+	l4 := make(map[string]string)
+	l4["namespace_id"] = ""
+	l4[core.LabelPodId.Key] = "aaaa-bbbb-cccc-dddd"
+
+	l5 := make(map[string]string)
+	l5["namespace_id"] = "123"
+	l5[core.LabelPodId.Key] = "aaaa-bbbb-cccc-dddd"
+
+	metricSet1 := core.MetricSet{
+		Labels: l,
+		MetricValues: map[string]core.MetricValue{
+			"/system.slice/-.mount//cpu/limit": {
+				ValueType:  core.ValueInt64,
+				MetricType: core.MetricCumulative,
+				IntValue:   123456,
+			},
+		},
+	}
+
+	metricSet2 := core.MetricSet{
+		Labels: l2,
+		MetricValues: map[string]core.MetricValue{
+			"/system.slice/dbus.service//cpu/usage": {
+				ValueType:  core.ValueInt64,
+				MetricType: core.MetricCumulative,
+				IntValue:   123456,
+			},
+		},
+	}
+
+	metricSet3 := core.MetricSet{
+		Labels: l3,
+		MetricValues: map[string]core.MetricValue{
+			"test/metric/1": {
+				ValueType:  core.ValueInt64,
+				MetricType: core.MetricCumulative,
+				IntValue:   123456,
+			},
+		},
+	}
+
+	metricSet4 := core.MetricSet{
+		Labels: l4,
+		MetricValues: map[string]core.MetricValue{
+			"test/metric/1": {
+				ValueType:  core.ValueInt64,
+				MetricType: core.MetricCumulative,
+				IntValue:   123456,
+			},
+		},
+	}
+
+	metricSet5 := core.MetricSet{
+		Labels: l5,
+		MetricValues: map[string]core.MetricValue{
+			"removeme": {
+				ValueType:  core.ValueFloat,
+				MetricType: core.MetricCumulative,
+				FloatValue: 1.23456,
+			},
+		},
+	}
+
+	data := core.DataBatch{
+		Timestamp: timestamp,
+		MetricSets: map[string]*core.MetricSet{
+			"pod1": &metricSet1,
+			"pod2": &metricSet2,
+			"pod3": &metricSet3,
+			"pod4": &metricSet4,
+			"pod5": &metricSet5,
+		},
+	}
+
+	fakeSink.ExportData(&data)
+	assert.Equal(t, 5, len(fakeSink.fakeDbClient.BatchPoints))
+}
+
+func TestCreateHoneycombSink(t *testing.T) {
+	stubHoneycombURL, err := url.Parse("?dataset=testdataset&writekey=testwritekey")
+	assert.NoError(t, err)
+
+	//create honeycomb sink
+	sink, err := NewHoneycombSink(stubHoneycombURL)
+	assert.NoError(t, err)
+
+	//check sink name
+	assert.Equal(t, sink.Name(), "Honeycomb Sink")
+}

--- a/metrics/sinks/honeycomb/honeycomb_test.go
+++ b/metrics/sinks/honeycomb/honeycomb_test.go
@@ -32,7 +32,6 @@ type fakeHoneycombDataSink struct {
 func newRawHoneycombSink() *honeycombSink {
 	return &honeycombSink{
 		client: honeycomb_common.FakeClient,
-		c:      honeycomb_common.Config,
 	}
 }
 
@@ -46,7 +45,7 @@ func TestStoreDataEmptyInput(t *testing.T) {
 	fakeSink := NewFakeSink()
 	dataBatch := core.DataBatch{}
 	fakeSink.ExportData(&dataBatch)
-	assert.Equal(t, 0, len(fakeSink.fakeDbClient.Measurements))
+	assert.Equal(t, 0, len(fakeSink.fakeDbClient.BatchPoints))
 }
 
 func TestStoreMultipleDataInput(t *testing.T) {

--- a/metrics/sinks/honeycomb/honeycomb_test.go
+++ b/metrics/sinks/honeycomb/honeycomb_test.go
@@ -29,18 +29,20 @@ type fakeHoneycombDataSink struct {
 	fakeDbClient *honeycomb_common.FakeHoneycombClient
 }
 
-func newRawHoneycombSink() *honeycombSink {
+func newRawHoneycombSink(client honeycomb_common.Client) *honeycombSink {
 	return &honeycombSink{
-		client: honeycomb_common.FakeClient,
+		client: client,
 	}
 }
 
 func NewFakeSink() fakeHoneycombDataSink {
+	fakeClient := honeycomb_common.NewFakeHoneycombClient()
 	return fakeHoneycombDataSink{
-		newRawHoneycombSink(),
-		honeycomb_common.FakeClient,
+		newRawHoneycombSink(fakeClient),
+		fakeClient,
 	}
 }
+
 func TestStoreDataEmptyInput(t *testing.T) {
 	fakeSink := NewFakeSink()
 	dataBatch := core.DataBatch{}


### PR DESCRIPTION
Writekey can now be added by specifying an environment variable.

Added a quick test that tests the BuildConfig and a basic Batch test.

Updating the manifest to use updated URI: https://github.com/honeycombio/kubernetes-manifests/pull/1

EDIT: fwiw, this repo seemed to be working before I started working on it. LMK if you're looking for something specific that needs improvement.

